### PR TITLE
merge in several improvements to the plugin

### DIFF
--- a/README
+++ b/README
@@ -4,18 +4,51 @@ Installation
 
 Follow the default redmine plugin installation steps at http://www.redmine.org/projects/redmine/wiki/Plugins
 
+Then set up the DB config via the admin panel in Administration > Plugins > Wiki SQL:
+
+    Configure a seperate user with read only minimal permissions to the database you want to use (may be redmine or any other unrelated database -
+    only MySQL supported for now, more available as needed?)
+
+    ALWAYS make sure it is a readonly user. Control how many resources (cpu/memory) can be consumed by this user, because any user of redmine
+    can cause queries to be executed by tricking an authorized user into viewing any comment editable by the attacker.
+
+    Then, for reading security, only users with 'SQL Authority' custom field value of 'True' will actually be able to view the tables.
+
 Usage:
 
-Put this inside a wiki page: {{sql( *Your Query* )}}
+Put this inside a wiki page: {{sql(somedatabasename)
+    select some 
+        from thing 
+        where blah = 81
+}}
 
-Example:
+Examples:
 
-{{sql(select id as 'ID', subject as 'Subject', DATE_FORMAT\(issues.due_date , '%d/%m/%Y'\) AS 'Due Date' from issues)}}
+{{sql(redmine)
+    select id as 'ID', 
+        subject as 'Subject', 
+        DATE_FORMAT(issues.due_date , '%d/%m/%Y') AS 'Due Date' 
+    from issues
+}}
 
-Known problems:
+{{sql(redmine)
+select 
+    curdate(), 
+    2+40, 
+    "If you can see this, it worked!"
+}}
 
-- User has to manually escape parenthesis with \
-
-Bug Fixes:
-
+Fixed former problems:
+- User has to manually escape parenthesis with \ [SOLVED]
+- User cannot format SQL across multiple lines for complex queries [SOLVED]
 - Can't change column's order [SOLVED]
+
+Added features
+- Returned text is itself textilized which can be quite nice when e.g., pulling formatted redmine text out of db!
+
+Known problems
+- Would still be nice to restrict EDITING queries rather than VIEWING them (would be more hassle)
+- Would be nice to allow auto-retextilization to support markdown and to make it optional
+- auto-retextilization can give an infinite loop if someone is so unwise as to make it refer to itself...
+
+

--- a/app/views/settings/_redmine_wiki_sql.html.erb
+++ b/app/views/settings/_redmine_wiki_sql.html.erb
@@ -1,0 +1,29 @@
+<em>
+Configure a seperate user with read only minimal permissions to the database you want to use (may be redmine or any other unrelated database -
+only MySQL supported for now, more available as needed?)
+
+<p>ALWAYS make sure it is a readonly user. Control how many resources (cpu/memory) can be consumed by this user, because any user of redmine
+can cause queries to be executed by tricking an authorized user into viewing any comment editable by the attacker.
+
+<p>Then, for reading security, only users with 'SQL Authority' custom field value of 'True' will actually be able to view the tables.
+</em><br /><br />
+
+<p><label>External Database Host</label>
+<%= text_field_tag 'settings[rdbms_host]', @settings['rdbms_host'], :size => 80 %>
+<br /><em>Hostname to connect to</em></p>
+
+<p><label>RDBMS Vendor</label>
+<%= select_tag 'settings[rdbms_vendor]', options_for_select(['MySQL'], @settings['rdbms_vendor']) %></p>
+
+<p><label>RDBMS Username</label>
+<%= text_field_tag 'settings[rdbms_username]', @settings['rdbms_username'], :size => 80 %>
+<br /><em>Database username. You should create a new user with limited readonly access</em></p>
+
+<p><label>RDBMS Password</label>
+<%= text_field_tag 'settings[rdbms_password]', @settings['rdbms_password'], :size => 80 %>
+<br /><em>Database password</em></p>
+
+<p><label>RDBMS Connection Port</label>
+<%= text_field_tag 'settings[rdbms_port]', @settings['rdbms_port'], :size => 10 %>
+<br /><em>Database port (try 3306 for MySQL)</em></p>
+

--- a/init.rb
+++ b/init.rb
@@ -1,58 +1,74 @@
 require 'redmine'
+require 'mysql2'
 require 'open-uri'
 require 'issue'
 
 Redmine::Plugin.register :redmine_wiki_sql do
-  name 'Redmine Wiki SQL'
-  author 'Rodrigo Ramalho'
+  name 'Secure Wiki SQL'
+  author 'Rodrigo Ramalho, Domingo Galdos'
   author_url 'http://www.rodrigoramalho.com/'
-  description 'Allows you to run SQL queries and have them shown on your wiki in table format'
-  version '0.0.1'
+  description 'Securely insert SQL-query-backed tables in the wiki from a relational database'
+  version '0.3.0'
+  settings :default => {'empty' => true}, :partial => 'settings/redmine_wiki_sql'
+
 
   Redmine::WikiFormatting::Macros.register do
     desc "Run SQL query"
     macro :sql do |obj, args, text|
+        # TODO: textilizable 
+        # TODO: Groups
+        sql_field_values = User.current.custom_field_values.select{ |cv| cv.custom_field.name == "SQL Authority" }
+        has_authority = !sql_field_values.empty? && '1' == sql_field_values.first.value
+        out_text = ""
+        if has_authority
+            _sentence = text
 
-        _sentence = args.join(",")
-        _sentence = _sentence.gsub("\\(", "(")
-        _sentence = _sentence.gsub("\\)", ")")
-        _sentence = _sentence.gsub("\\*", "*")
+            # TODO: support other RDBMS vendors besides MySQL, eg Postgres, MSSQL, SQLite, Oracle
+            dbh = Mysql2::Client.new(
+                :host => Setting.plugin_redmine_wiki_sql['rdbms_host'],
+                :username => Setting.plugin_redmine_wiki_sql['rdbms_username'],
+                :password => Setting.plugin_redmine_wiki_sql['rdbms_password'],
+                :port => Setting.plugin_redmine_wiki_sql['rdbms_port'],
+                :database => args[0],
+                :read_timeout => 30,
+                :write_timeout => 30,
+                :connect_timeout => 30
+            )
+            result = dbh.query(_sentence)
 
-        result = ActiveRecord::Base.connection.execute(_sentence)
-        unless result.nil?
-          unless result.num_rows() == 0
-            column_names = []
-            for columns in result.fetch_fields.each do
-              column_names += columns.name.to_a
-            end
+            unless result.nil?
+              #unless result.num_rows() == 0
+              unless result.fields.length == 0
+                column_names = result.fields
 
-            _thead = '<tr>'
-            column_names.each do |column_name|
-              _thead << '<th>' + column_name.to_s + '</th>'
-            end
-            _thead << '</tr>'
-
-            _tbody = ''
-            result.each_hash do |record|
-              unless record.nil?
-                _tbody << '<tr>'
+                _thead = '<tr>'
                 column_names.each do |column_name|
-                  _tbody << '<td>' + record[column_name].to_s + '</td>'
+                  _thead << '<th>' + column_name.to_s + '</th>'
                 end
-                _tbody << '</tr>'
-              end 
+                _thead << '</tr>'
+
+                _tbody = ''
+                result.each do |record|
+                  unless record.nil?
+                    _tbody << '<tr>'
+                    jj = 0
+                    column_names.each do |column_name|
+                      raw_cell = record[column_names[jj]].to_s
+                      formatted_cell =  textilizable( raw_cell )
+                      _tbody << '<td>' + formatted_cell + '</td>'
+                      jj = jj + 1
+                    end
+                    _tbody << '</tr>'
+                  end 
+                end
+                out_text = '<table>' << _thead << _tbody << '</table>' 
+              end
             end
-
-            text = '<table>' << _thead << _tbody << '</table>' 
-
-            text.html_safe
-          else
-            ''.html_safe
-          end
-        else
-          ''.html_safe
         end
+        out_text.html_safe
     end 
   end
 	
 end
+
+


### PR DESCRIPTION
Hello, 

Thanks for the original redmine_wiki_sql plugin. Found it useful, and added several needed improvements
- add security features so it's safe to use in production: (1) allow configuring DB separately for wiki_sql (via the admin gui) so you can create a less-privileged DB user, instead of reusing the rails connection (2)
- fix the column ordering/naming bug
- change the syntax, which improves quite a bit: (1) no more having to escape parentheses (2) use as much whitespace as you need to make SQL query pretty (3) select a specific db per query to save time writing table names
- automatically format returned text in textilized format (useful when listing stuff like issues, etc)

With that said I also added two flaws (1) now it can only really work with MySQL (2) if an authorized SQL user foolishly writes a query that returns the very same text of the query, you can end up with an infinite query and crash redmine

At least for my uses, adding the security alone made it worth it (since I'm only using it with MySQL) and really would not have been able to use it at all otherwise. But YMMV and some users (especially if not using MySQL!) might not find the other improvements worth the downside

Thanks again for the original plugin and open sourcing it!
